### PR TITLE
Iter24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ vendor/
 # IDEs directories
 .idea
 .vscode
+.json
+.exe

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,22 @@ build:
 	go mod download
 	go build .\cmd\shortener\main.go
 	go build .\cmd\staticlint\mycheck.go
+
 test:
 	go test ./... -v -coverprofile cover.out
 	go tool cover -func cover.out
+
 linter: build
 	./mycheck.exe -shadow=false ./pkg/server/server.go
 	./mycheck.exe -all ./cmd/shortener/main.go
 	./mycheck.exe -all ./pkg/storage/...
+
+stylization: 
+	goimports -local "github.com/Dorrrke/shortener-url" -w .\cmd\
+	goimports -local "github.com/Dorrrke/shortener-url" -w .\internal\
+	goimports -local "github.com/Dorrrke/shortener-url" -w .\pkg\
+	
 run: test build
 	./main.exe
+
 all: test linter build run

--- a/cmd/staticlint/mycheck.go
+++ b/cmd/staticlint/mycheck.go
@@ -19,7 +19,6 @@ package main
 import (
 	"strings"
 
-	"github.com/Dorrrke/shortener-url/pkg/linter"
 	"github.com/fatih/errwrap/errwrap"
 	"github.com/mdempsky/maligned/passes/maligned"
 	"golang.org/x/tools/go/analysis"
@@ -71,6 +70,8 @@ import (
 	"golang.org/x/tools/go/analysis/passes/unusedwrite"
 	"golang.org/x/tools/go/analysis/passes/usesgenerics"
 	"honnef.co/go/tools/staticcheck"
+
+	"github.com/Dorrrke/shortener-url/pkg/linter"
 )
 
 // main - функция входа для запуска Multicheker.

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,8 @@
 {
-    "server_address": "localhost:8080",
-    "base_url": "localhost:8080",
-    "file_storage_path": "/path/to/file.db",
-    "database_dsn": "",
-    "enable_https": false
+    "server_address": "localhost:9090",
+    "base_url": "localhost:9080",
+    "file_storage_path": "",
+    "database_dsn": "postgres://postgres:6406655@localhost:5432/postgres",
+    "enable_https": false,
+    "trusted_subnet": "127.0.0.0/8"
 } 

--- a/internal/config/appConfig.go
+++ b/internal/config/appConfig.go
@@ -22,6 +22,7 @@ type AppConfig struct {
 	FileStoragePath string `json:"file_storage_path" env:"FILE_STORAGE_PATH,required"`
 	DatabaseDsn     string `json:"database_dsn" env:"DATABASE_DSN,required"`
 	EnableHTTPS     bool   `json:"enable_https"`
+	TrustedSubnet   string `json:"trusted_subnet" env:"TRUSTED_SUBNET,required"`
 }
 
 // MustLoad - обязательная к запуску функция создающая файл конфига.
@@ -35,6 +36,7 @@ func MustLoad() *AppConfig {
 	flag.StringVar(&cfg.BaseURL, "b", "", "address and port to run short URL")
 	flag.StringVar(&cfg.FileStoragePath, "f", "", "storage file path")
 	flag.StringVar(&cfg.DatabaseDsn, "d", "", "databse addr")
+	flag.StringVar(&cfg.TrustedSubnet, "t", "", "trusted subnet")
 	httpsFlag := flag.Bool("s", false, "use https server")
 	flag.Parse()
 	cfg.EnableHTTPS = *httpsFlag
@@ -53,6 +55,9 @@ func MustLoad() *AppConfig {
 	if cfg.DatabaseDsn == "" {
 		cfg.DatabaseDsn = os.Getenv("DATABASE_DSN")
 	}
+	if cfg.TrustedSubnet == "" {
+		cfg.TrustedSubnet = os.Getenv("TRUSTED_SUBNET")
+	}
 	if cfg.FileStoragePath == "" {
 		cfg.FileStoragePath = os.Getenv("FILE_STORAGE_PATH")
 		if cfg.FileStoragePath == "" {
@@ -61,6 +66,10 @@ func MustLoad() *AppConfig {
 	}
 	if cfg.ServerAddress == "" {
 		cfg.ServerAddress = os.Getenv("SERVER_ADDRESS")
+	}
+
+	if cfg.TrustedSubnet == "" {
+		cfg.TrustedSubnet = os.Getenv("TRUSTED_SUBNET")
 	}
 
 	if cfg.ServerAddress == "" && cfg.BaseURL == "" && cfg.DatabaseDsn == "" {

--- a/internal/config/appConfig.go
+++ b/internal/config/appConfig.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Dorrrke/shortener-url/internal/logger"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/logger"
 )
 
 // FilePath — константа с названием файла для хранения данных при отсутствии подключения к бд.

--- a/mocks/mock_storage.go
+++ b/mocks/mock_storage.go
@@ -5,162 +5,178 @@
 package mock_storage
 
 import (
-	context "context"
-	reflect "reflect"
+        context "context"
+        reflect "reflect"
 
-	models "github.com/Dorrrke/shortener-url/pkg/models"
-	gomock "github.com/golang/mock/gomock"
+        models "github.com/Dorrrke/shortener-url/pkg/models"
+        gomock "github.com/golang/mock/gomock"
 )
 
 // MockStorage is a mock of Storage interface.
 type MockStorage struct {
-	ctrl     *gomock.Controller
-	recorder *MockStorageMockRecorder
+        ctrl     *gomock.Controller
+        recorder *MockStorageMockRecorder
 }
 
 // MockStorageMockRecorder is the mock recorder for MockStorage.
 type MockStorageMockRecorder struct {
-	mock *MockStorage
+        mock *MockStorage
 }
 
 // NewMockStorage creates a new mock instance.
 func NewMockStorage(ctrl *gomock.Controller) *MockStorage {
-	mock := &MockStorage{ctrl: ctrl}
-	mock.recorder = &MockStorageMockRecorder{mock}
-	return mock
+        mock := &MockStorage{ctrl: ctrl}
+        mock.recorder = &MockStorageMockRecorder{mock}
+        return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
-	return m.recorder
+        return m.recorder
 }
 
 // CheckDBConnect mocks base method.
 func (m *MockStorage) CheckDBConnect(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDBConnect", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "CheckDBConnect", arg0)
+        ret0, _ := ret[0].(error)
+        return ret0
 }
 
 // CheckDBConnect indicates an expected call of CheckDBConnect.
 func (mr *MockStorageMockRecorder) CheckDBConnect(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDBConnect", reflect.TypeOf((*MockStorage)(nil).CheckDBConnect), arg0)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDBConnect", reflect.TypeOf((*MockStorage)(nil).CheckDBConnect), arg0)
 }
 
 // Clear mocks base method.
 func (m *MockStorage) Clear(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clear", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "Clear", arg0)
+        ret0, _ := ret[0].(error)
+        return ret0
 }
 
 // Clear indicates an expected call of Clear.
 func (mr *MockStorageMockRecorder) Clear(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockStorage)(nil).Clear), arg0)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockStorage)(nil).Clear), arg0)
 }
 
 // CreateTable mocks base method.
 func (m *MockStorage) CreateTable(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTable", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "CreateTable", arg0)
+        ret0, _ := ret[0].(error)
+        return ret0
 }
 
 // CreateTable indicates an expected call of CreateTable.
 func (mr *MockStorageMockRecorder) CreateTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTable", reflect.TypeOf((*MockStorage)(nil).CreateTable), arg0)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTable", reflect.TypeOf((*MockStorage)(nil).CreateTable), arg0)
 }
 
 // GetAllUrls mocks base method.
 func (m *MockStorage) GetAllUrls(arg0 context.Context, arg1 string) ([]models.URLModel, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUrls", arg0, arg1)
-	ret0, _ := ret[0].([]models.URLModel)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "GetAllUrls", arg0, arg1)
+        ret0, _ := ret[0].([]models.URLModel)
+        ret1, _ := ret[1].(error)
+        return ret0, ret1
 }
 
 // GetAllUrls indicates an expected call of GetAllUrls.
 func (mr *MockStorageMockRecorder) GetAllUrls(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUrls", reflect.TypeOf((*MockStorage)(nil).GetAllUrls), arg0, arg1)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUrls", reflect.TypeOf((*MockStorage)(nil).GetAllUrls), arg0, arg1)
 }
 
 // GetOriginalURLByShort mocks base method.
 func (m *MockStorage) GetOriginalURLByShort(arg0 context.Context, arg1 string) (string, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOriginalURLByShort", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "GetOriginalURLByShort", arg0, arg1)
+        ret0, _ := ret[0].(string)
+        ret1, _ := ret[1].(bool)
+        ret2, _ := ret[2].(error)
+        return ret0, ret1, ret2
 }
 
 // GetOriginalURLByShort indicates an expected call of GetOriginalURLByShort.
 func (mr *MockStorageMockRecorder) GetOriginalURLByShort(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalURLByShort", reflect.TypeOf((*MockStorage)(nil).GetOriginalURLByShort), arg0, arg1)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalURLByShort", reflect.TypeOf((*MockStorage)(nil).GetOriginalURLByShort), arg0, arg1)
 }
 
 // GetShortByOriginalURL mocks base method.
 func (m *MockStorage) GetShortByOriginalURL(arg0 context.Context, arg1 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShortByOriginalURL", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "GetShortByOriginalURL", arg0, arg1)
+        ret0, _ := ret[0].(string)
+        ret1, _ := ret[1].(error)
+        return ret0, ret1
 }
 
 // GetShortByOriginalURL indicates an expected call of GetShortByOriginalURL.
 func (mr *MockStorageMockRecorder) GetShortByOriginalURL(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShortByOriginalURL", reflect.TypeOf((*MockStorage)(nil).GetShortByOriginalURL), arg0, arg1)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShortByOriginalURL", reflect.TypeOf((*MockStorage)(nil).GetShortByOriginalURL), arg0, arg1)
+}
+
+// GetStats mocks base method.
+func (m *MockStorage) GetStats(arg0 context.Context) (int, int, error) {
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "GetStats", arg0)
+        ret0, _ := ret[0].(int)
+        ret1, _ := ret[1].(int)
+        ret2, _ := ret[2].(error)
+        return ret0, ret1, ret2
+}
+
+// GetStats indicates an expected call of GetStats.
+func (mr *MockStorageMockRecorder) GetStats(arg0 interface{}) *gomock.Call {
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockStorage)(nil).GetStats), arg0)
 }
 
 // InsertBanchURL mocks base method.
 func (m *MockStorage) InsertBanchURL(arg0 context.Context, arg1 []models.BantchURL) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertBanchURL", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "InsertBanchURL", arg0, arg1)
+        ret0, _ := ret[0].(error)
+        return ret0
 }
 
 // InsertBanchURL indicates an expected call of InsertBanchURL.
 func (mr *MockStorageMockRecorder) InsertBanchURL(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBanchURL", reflect.TypeOf((*MockStorage)(nil).InsertBanchURL), arg0, arg1)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBanchURL", reflect.TypeOf((*MockStorage)(nil).InsertBanchURL), arg0, arg1)
 }
 
 // InsertURL mocks base method.
 func (m *MockStorage) InsertURL(arg0 context.Context, arg1, arg2, arg3 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertURL", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "InsertURL", arg0, arg1, arg2, arg3)
+        ret0, _ := ret[0].(error)
+        return ret0
 }
 
 // InsertURL indicates an expected call of InsertURL.
 func (mr *MockStorageMockRecorder) InsertURL(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertURL", reflect.TypeOf((*MockStorage)(nil).InsertURL), arg0, arg1, arg2, arg3)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertURL", reflect.TypeOf((*MockStorage)(nil).InsertURL), arg0, arg1, arg2, arg3)
 }
 
 // SetDeleteURLStatus mocks base method.
 func (m *MockStorage) SetDeleteURLStatus(arg0 context.Context, arg1 []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDeleteURLStatus", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "SetDeleteURLStatus", arg0, arg1)
+        ret0, _ := ret[0].(error)
+        return ret0
 }
 
 // SetDeleteURLStatus indicates an expected call of SetDeleteURLStatus.
 func (mr *MockStorageMockRecorder) SetDeleteURLStatus(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeleteURLStatus", reflect.TypeOf((*MockStorage)(nil).SetDeleteURLStatus), arg0, arg1)
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeleteURLStatus", reflect.TypeOf((*MockStorage)(nil).SetDeleteURLStatus), arg0, arg1)
 }

--- a/mocks/mock_storage.go
+++ b/mocks/mock_storage.go
@@ -5,178 +5,179 @@
 package mock_storage
 
 import (
-        context "context"
-        reflect "reflect"
+	context "context"
+	reflect "reflect"
 
-        models "github.com/Dorrrke/shortener-url/pkg/models"
-        gomock "github.com/golang/mock/gomock"
+	gomock "github.com/golang/mock/gomock"
+
+	models "github.com/Dorrrke/shortener-url/pkg/models"
 )
 
 // MockStorage is a mock of Storage interface.
 type MockStorage struct {
-        ctrl     *gomock.Controller
-        recorder *MockStorageMockRecorder
+	ctrl     *gomock.Controller
+	recorder *MockStorageMockRecorder
 }
 
 // MockStorageMockRecorder is the mock recorder for MockStorage.
 type MockStorageMockRecorder struct {
-        mock *MockStorage
+	mock *MockStorage
 }
 
 // NewMockStorage creates a new mock instance.
 func NewMockStorage(ctrl *gomock.Controller) *MockStorage {
-        mock := &MockStorage{ctrl: ctrl}
-        mock.recorder = &MockStorageMockRecorder{mock}
-        return mock
+	mock := &MockStorage{ctrl: ctrl}
+	mock.recorder = &MockStorageMockRecorder{mock}
+	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
-        return m.recorder
+	return m.recorder
 }
 
 // CheckDBConnect mocks base method.
 func (m *MockStorage) CheckDBConnect(arg0 context.Context) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "CheckDBConnect", arg0)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDBConnect", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // CheckDBConnect indicates an expected call of CheckDBConnect.
 func (mr *MockStorageMockRecorder) CheckDBConnect(arg0 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDBConnect", reflect.TypeOf((*MockStorage)(nil).CheckDBConnect), arg0)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDBConnect", reflect.TypeOf((*MockStorage)(nil).CheckDBConnect), arg0)
 }
 
 // Clear mocks base method.
 func (m *MockStorage) Clear(arg0 context.Context) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "Clear", arg0)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clear", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Clear indicates an expected call of Clear.
 func (mr *MockStorageMockRecorder) Clear(arg0 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockStorage)(nil).Clear), arg0)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockStorage)(nil).Clear), arg0)
 }
 
 // CreateTable mocks base method.
 func (m *MockStorage) CreateTable(arg0 context.Context) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "CreateTable", arg0)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTable", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // CreateTable indicates an expected call of CreateTable.
 func (mr *MockStorageMockRecorder) CreateTable(arg0 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTable", reflect.TypeOf((*MockStorage)(nil).CreateTable), arg0)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTable", reflect.TypeOf((*MockStorage)(nil).CreateTable), arg0)
 }
 
 // GetAllUrls mocks base method.
 func (m *MockStorage) GetAllUrls(arg0 context.Context, arg1 string) ([]models.URLModel, error) {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "GetAllUrls", arg0, arg1)
-        ret0, _ := ret[0].([]models.URLModel)
-        ret1, _ := ret[1].(error)
-        return ret0, ret1
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllUrls", arg0, arg1)
+	ret0, _ := ret[0].([]models.URLModel)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetAllUrls indicates an expected call of GetAllUrls.
 func (mr *MockStorageMockRecorder) GetAllUrls(arg0, arg1 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUrls", reflect.TypeOf((*MockStorage)(nil).GetAllUrls), arg0, arg1)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUrls", reflect.TypeOf((*MockStorage)(nil).GetAllUrls), arg0, arg1)
 }
 
 // GetOriginalURLByShort mocks base method.
 func (m *MockStorage) GetOriginalURLByShort(arg0 context.Context, arg1 string) (string, bool, error) {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "GetOriginalURLByShort", arg0, arg1)
-        ret0, _ := ret[0].(string)
-        ret1, _ := ret[1].(bool)
-        ret2, _ := ret[2].(error)
-        return ret0, ret1, ret2
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOriginalURLByShort", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetOriginalURLByShort indicates an expected call of GetOriginalURLByShort.
 func (mr *MockStorageMockRecorder) GetOriginalURLByShort(arg0, arg1 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalURLByShort", reflect.TypeOf((*MockStorage)(nil).GetOriginalURLByShort), arg0, arg1)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalURLByShort", reflect.TypeOf((*MockStorage)(nil).GetOriginalURLByShort), arg0, arg1)
 }
 
 // GetShortByOriginalURL mocks base method.
 func (m *MockStorage) GetShortByOriginalURL(arg0 context.Context, arg1 string) (string, error) {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "GetShortByOriginalURL", arg0, arg1)
-        ret0, _ := ret[0].(string)
-        ret1, _ := ret[1].(error)
-        return ret0, ret1
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetShortByOriginalURL", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetShortByOriginalURL indicates an expected call of GetShortByOriginalURL.
 func (mr *MockStorageMockRecorder) GetShortByOriginalURL(arg0, arg1 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShortByOriginalURL", reflect.TypeOf((*MockStorage)(nil).GetShortByOriginalURL), arg0, arg1)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShortByOriginalURL", reflect.TypeOf((*MockStorage)(nil).GetShortByOriginalURL), arg0, arg1)
 }
 
 // GetStats mocks base method.
 func (m *MockStorage) GetStats(arg0 context.Context) (int, int, error) {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "GetStats", arg0)
-        ret0, _ := ret[0].(int)
-        ret1, _ := ret[1].(int)
-        ret2, _ := ret[2].(error)
-        return ret0, ret1, ret2
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStats", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetStats indicates an expected call of GetStats.
 func (mr *MockStorageMockRecorder) GetStats(arg0 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockStorage)(nil).GetStats), arg0)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockStorage)(nil).GetStats), arg0)
 }
 
 // InsertBanchURL mocks base method.
 func (m *MockStorage) InsertBanchURL(arg0 context.Context, arg1 []models.BantchURL) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "InsertBanchURL", arg0, arg1)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertBanchURL", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // InsertBanchURL indicates an expected call of InsertBanchURL.
 func (mr *MockStorageMockRecorder) InsertBanchURL(arg0, arg1 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBanchURL", reflect.TypeOf((*MockStorage)(nil).InsertBanchURL), arg0, arg1)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBanchURL", reflect.TypeOf((*MockStorage)(nil).InsertBanchURL), arg0, arg1)
 }
 
 // InsertURL mocks base method.
 func (m *MockStorage) InsertURL(arg0 context.Context, arg1, arg2, arg3 string) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "InsertURL", arg0, arg1, arg2, arg3)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertURL", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // InsertURL indicates an expected call of InsertURL.
 func (mr *MockStorageMockRecorder) InsertURL(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertURL", reflect.TypeOf((*MockStorage)(nil).InsertURL), arg0, arg1, arg2, arg3)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertURL", reflect.TypeOf((*MockStorage)(nil).InsertURL), arg0, arg1, arg2, arg3)
 }
 
 // SetDeleteURLStatus mocks base method.
 func (m *MockStorage) SetDeleteURLStatus(arg0 context.Context, arg1 []string) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "SetDeleteURLStatus", arg0, arg1)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDeleteURLStatus", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SetDeleteURLStatus indicates an expected call of SetDeleteURLStatus.
 func (mr *MockStorageMockRecorder) SetDeleteURLStatus(arg0, arg1 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeleteURLStatus", reflect.TypeOf((*MockStorage)(nil).SetDeleteURLStatus), arg0, arg1)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeleteURLStatus", reflect.TypeOf((*MockStorage)(nil).SetDeleteURLStatus), arg0, arg1)
 }

--- a/pkg/models/json_models.go
+++ b/pkg/models/json_models.go
@@ -29,6 +29,7 @@ type URLModel struct {
 	OriginalID string `json:"original_url"`
 }
 
+// StatModel - модель для возврата статистики при запросе из довереной подсети.
 type StatModel struct {
 	URLsCount  int `json:"urls"`
 	UsercCount int `json:"users"`

--- a/pkg/models/json_models.go
+++ b/pkg/models/json_models.go
@@ -29,6 +29,11 @@ type URLModel struct {
 	OriginalID string `json:"original_url"`
 }
 
+type StatModel struct {
+	URLsCount  int `json:"urls"`
+	UsercCount int `json:"users"`
+}
+
 // BantchURL - для отправки на сохранение в базу данных нескольких скоращнных url сразу.
 type BantchURL struct {
 	OriginalURL string

--- a/pkg/server/CheckDBConnectionHandler_test.go
+++ b/pkg/server/CheckDBConnectionHandler_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	mock_storage "github.com/Dorrrke/shortener-url/mocks"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	mock_storage "github.com/Dorrrke/shortener-url/mocks"
 )
 
 func TestCheckDBConnectionHandler(t *testing.T) {

--- a/pkg/server/DeleteURLHandler_test.go
+++ b/pkg/server/DeleteURLHandler_test.go
@@ -7,14 +7,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Dorrrke/shortener-url/internal/config"
-	"github.com/Dorrrke/shortener-url/internal/logger"
-	mock_storage "github.com/Dorrrke/shortener-url/mocks"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/config"
+	"github.com/Dorrrke/shortener-url/internal/logger"
+	mock_storage "github.com/Dorrrke/shortener-url/mocks"
 )
 
 func TestDeleteURLHandler(t *testing.T) {

--- a/pkg/server/GetAllUrls_test.go
+++ b/pkg/server/GetAllUrls_test.go
@@ -7,14 +7,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Dorrrke/shortener-url/internal/logger"
-	mock_storage "github.com/Dorrrke/shortener-url/mocks"
-	"github.com/Dorrrke/shortener-url/pkg/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/logger"
+	mock_storage "github.com/Dorrrke/shortener-url/mocks"
+	"github.com/Dorrrke/shortener-url/pkg/models"
 )
 
 func TestGetAllUrls(t *testing.T) {

--- a/pkg/server/InsertBatchHandler_test.go
+++ b/pkg/server/InsertBatchHandler_test.go
@@ -6,14 +6,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Dorrrke/shortener-url/internal/config"
-	"github.com/Dorrrke/shortener-url/internal/logger"
-	mock_storage "github.com/Dorrrke/shortener-url/mocks"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/config"
+	"github.com/Dorrrke/shortener-url/internal/logger"
+	mock_storage "github.com/Dorrrke/shortener-url/mocks"
 )
 
 var db = "postgres://postgres:6406655@localhost:5432/postgres"

--- a/pkg/server/example_test.go
+++ b/pkg/server/example_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"github.com/Dorrrke/shortener-url/internal/logger"
-	"github.com/Dorrrke/shortener-url/pkg/storage"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-resty/resty/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/logger"
+	"github.com/Dorrrke/shortener-url/pkg/storage"
 )
 
 func ExampleServer_GetAllUrls() {

--- a/pkg/server/getOriginalURLHandler_test.go
+++ b/pkg/server/getOriginalURLHandler_test.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Dorrrke/shortener-url/internal/config"
-	"github.com/Dorrrke/shortener-url/pkg/storage"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Dorrrke/shortener-url/internal/config"
+	"github.com/Dorrrke/shortener-url/pkg/storage"
 )
 
 func TestGetOriginalURLHandler(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,13 +18,14 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pkg/errors"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/Dorrrke/shortener-url/internal/config"
 	"github.com/Dorrrke/shortener-url/internal/logger"
 	"github.com/Dorrrke/shortener-url/pkg/models"
 	"github.com/Dorrrke/shortener-url/pkg/storage"
-	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
-	"go.uber.org/zap"
 )
 
 // SecretKey - Секретный ключ для создания JWT токена.

--- a/pkg/server/server_functions_test.go
+++ b/pkg/server/server_functions_test.go
@@ -3,9 +3,10 @@ package server
 import (
 	"testing"
 
-	"github.com/Dorrrke/shortener-url/internal/logger"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/logger"
 )
 
 func TestGetUID(t *testing.T) {

--- a/pkg/server/shortenerJsonURLHandler_test.go
+++ b/pkg/server/shortenerJsonURLHandler_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/Dorrrke/shortener-url/internal/config"
 	"github.com/Dorrrke/shortener-url/pkg/storage"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestShortenerJsonURLHandler(t *testing.T) {

--- a/pkg/server/shortenerURLHandler_test.go
+++ b/pkg/server/shortenerURLHandler_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/Dorrrke/shortener-url/internal/config"
 	"github.com/Dorrrke/shortener-url/pkg/storage"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestShortenerURLHandler(t *testing.T) {

--- a/pkg/storage/URLstorage.go
+++ b/pkg/storage/URLstorage.go
@@ -25,6 +25,7 @@ type Storage interface {
 	CreateTable(ctx context.Context) error
 	InsertBanchURL(ctx context.Context, value []models.BantchURL) error
 	SetDeleteURLStatus(ctx context.Context, value []string) error
+	GetStats(ctx context.Context) (int, int, error)
 	Clear(ctx context.Context) error
 }
 
@@ -89,6 +90,10 @@ func (s *MemStorage) CreateTable(ctx context.Context) error {
 // Так как это MemStorage возвращает ошибку, что бд не подключена.
 func (s *MemStorage) SetDeleteURLStatus(ctx context.Context, value []string) error {
 	return errors.New("DataBase is not init")
+}
+
+func (s *MemStorage) GetStats(ctx context.Context) (int, int, error) {
+	return -1, -1, errors.New("DataBase is not init")
 }
 
 // GetAllUrls - метод получения всех сокращенных url пользвателя из бд.
@@ -196,6 +201,21 @@ func (s *DBStorage) GetAllUrls(ctx context.Context, userID string) ([]models.URL
 	}
 
 	return urls, nil
+}
+
+func (s *DBStorage) GetStats(ctx context.Context) (int, int, error) {
+	getStatStr := `SELECT COUNT(short), COUNT(DISTINCT uid) FROM short_urls`
+
+	row := s.DB.QueryRow(ctx, getStatStr)
+	var URLCount int
+	var usersCount int
+
+	if err := row.Scan(&URLCount, &usersCount); err != nil {
+		return -1, -1, err
+	}
+
+	return URLCount, usersCount, nil
+
 }
 
 // CreateTable - метод создания таблицы в базе данных, если ее не существует.

--- a/pkg/storage/URLstorage.go
+++ b/pkg/storage/URLstorage.go
@@ -93,6 +93,8 @@ func (s *MemStorage) SetDeleteURLStatus(ctx context.Context, value []string) err
 	return errors.New("DataBase is not init")
 }
 
+// GetAllUrls - метод получения количества пользователей сервиса и количество всех сокращенных URL.
+// Так как это MemStorage возвращает ошибку, что бд не подключена.
 func (s *MemStorage) GetStats(ctx context.Context) (int, int, error) {
 	return -1, -1, errors.New("DataBase is not init")
 }
@@ -204,6 +206,7 @@ func (s *DBStorage) GetAllUrls(ctx context.Context, userID string) ([]models.URL
 	return urls, nil
 }
 
+// GetAllUrls - метод получения количества пользователей сервиса и количество всех сокращенных URL.
 func (s *DBStorage) GetStats(ctx context.Context) (int, int, error) {
 	getStatStr := `SELECT COUNT(short), COUNT(DISTINCT uid) FROM short_urls`
 

--- a/pkg/storage/URLstorage.go
+++ b/pkg/storage/URLstorage.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Dorrrke/shortener-url/internal/logger"
-	"github.com/Dorrrke/shortener-url/pkg/models"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
+	"github.com/Dorrrke/shortener-url/internal/logger"
+	"github.com/Dorrrke/shortener-url/pkg/models"
 )
 
 // ErrMemStorageError ошибка при попыттке записать уже существующий url в MemStorage.


### PR DESCRIPTION
Добавлено:

- Новый эндпоинт `GET /api/internal/stats`, возвращающий в ответ объект:

```
{
  "urls": <int>, // количество сокращённых URL в сервисе
  "users": <int> // количество пользователей в сервисе
} 
```

- Поле trusted_subnet в конфигурационный JSON-файл HTTP-сервера (тип string, переменная окружения TRUSTED_SUBNET, флаг -t), в которое можно передать строковое представление бесклассовой адресации (CIDR).

При запросе эндпоинта `/api/internal/stats` проверяется, что переданный в заголовке запроса X-Real-IP IP-адрес клиента входит в доверенную подсеть, в противном случае возвращается статус ответа 403 Forbidden.
При пустом значении переменной `trusted_subnet` доступ к эндпоинту  запрещён для любого входящего запроса.